### PR TITLE
Apply set System/component ID. 

### DIFF
--- a/include/mav/Message.h
+++ b/include/mav/Message.h
@@ -403,8 +403,12 @@ namespace mav {
             header().incompatFlags() = 0;
             header().compatFlags() = 0;
             header().seq() = seq;
-            header().systemId() = sender.system_id;
-            header().componentId() = sender.component_id;
+            if (header().systemId() == 0) {
+                header().systemId() = sender.system_id;
+            }
+            if (header().componentId() == 0) {
+                header().componentId() = sender.component_id;
+            }
             header().msgId() = _message_definition->id();
 
             CRC crc;


### PR DESCRIPTION
Only set the default system and component id, if they have not been set yet, else use the system and component id in the message. Useful when routing messages, to keep those values.