### PR TITLE
Do not build tests if BUILD_TESTING=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,8 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/mav DESTINATION include)
 set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 
 include(CPack)
+include(CTest)
 
-add_subdirectory(tests)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(CTest)
-
 add_executable(tests
         test_main.cpp
         MessageSet.cpp


### PR DESCRIPTION
`include(CTest)` defines `BUILD_TESTING` (set to `ON` by default). I think it makes sense to use it, such that people don't have to build the tests if they don't want to.

To disable the tests:

```
cmake -DBUILD_TESTING=OFF -Bbuild -S.
cmake --build build
```