### PR TITLE
Add direct IO network interface

### DIFF
--- a/include/mav/DirectIO.h
+++ b/include/mav/DirectIO.h
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2023, libmav development team
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name libmav nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef LIBMAVLINK_DIRECTIO_H
+#define LIBMAVLINK_DIRECTIO_H
+
+#include <atomic>
+#include <sys/types.h>
+#include <utility>
+#include <vector>
+#include <array>
+#include <functional>
+#include <cstdint>
+#include "Network.h"
+
+namespace mav {
+
+    class DirectIO : public mav::NetworkInterface {
+
+    public:
+        using SendCallback = std::function<void(const uint8_t* buf, uint32_t len)>;
+        using ReceiveCallback = std::function<ssize_t(uint8_t* buf, uint32_t len)>;
+
+    private:
+        static constexpr size_t RX_BUFFER_SIZE = 2048;
+
+        mutable std::atomic_bool _should_terminate{false};
+
+        std::array<uint8_t, RX_BUFFER_SIZE> _rx_buffer;
+        int _bytes_available = 0;
+        ConnectionPartner _partner = {0, 0, false};
+
+        SendCallback _send_callback{nullptr};
+        ReceiveCallback _receive_callback{nullptr};
+
+    public:
+            DirectIO(SendCallback send_callback, ReceiveCallback receive_callback) :
+             _send_callback(send_callback),
+            _receive_callback(receive_callback)
+        {
+        }
+
+        void stop() {
+            _should_terminate.store(true);
+        }
+
+        void close() override {
+            stop();
+        }
+
+        ConnectionPartner receive(uint8_t *destination, uint32_t size) override {
+            if (!_receive_callback) {
+                // TODO: use that to signal nothing?
+                throw NetworkInterfaceInterrupt();
+            }
+
+            // Receive as many messages as needed to have enough bytes available (none if already enough bytes)
+            while (_bytes_available < size && !_should_terminate.load()) {
+                // If there are residual bytes from last packet, but not enough for parsing new packet, clear out
+                _bytes_available = 0;
+                const ssize_t ret = _receive_callback(_rx_buffer.data(), RX_BUFFER_SIZE);
+                if (ret < 0) {
+                    throw NetworkError("Could not receive from callback");
+                }
+                _bytes_available += static_cast<int>(ret);
+            }
+
+            if (_should_terminate.load()) {
+                throw NetworkInterfaceInterrupt();
+            }
+
+            std::copy(_rx_buffer.begin(), _rx_buffer.begin() + size, destination);
+            _bytes_available -= static_cast<int>(size);
+            std::copy(_rx_buffer.begin() + size, _rx_buffer.begin() + size + _bytes_available, _rx_buffer.begin());
+            return _partner;
+        }
+
+        void send(const uint8_t *data, uint32_t size, ConnectionPartner target) override {
+            if (!_send_callback) {
+                return;
+            }
+            _send_callback(data, size);
+        }
+
+        void markSyncing() override {
+            // we're out of sync. The beginning of a packet was not the magic number we expected,
+            // therefore, we can discard the rest of the packet and just receive another datagram.
+            _bytes_available = 0;
+        }
+
+        bool isConnectionOriented() const override {
+            // even though UDP is not connection oriented, we can use it as if it was,
+            return true;
+        }
+
+        virtual ~DirectIO() {
+            stop();
+        }
+    };
+}
+
+#endif //LIBMAVLINK_DIRECT_IO

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,9 @@ add_executable(tests
         Network.cpp
         MessageFieldIterator.cpp
         UDP.cpp
-        TCP.cpp)
+        TCP.cpp
+        DirectIO.cpp
+)
 
 add_test(NAME tests COMMAND tests)
 

--- a/tests/DirectIO.cpp
+++ b/tests/DirectIO.cpp
@@ -1,0 +1,100 @@
+//
+// Created by thomas on 24.02.23.
+//
+#include <cstdint>
+#include <future>
+#include <chrono>
+#include <thread>
+#include "doctest.h"
+#include "mav/Message.h"
+#include "mav/Network.h"
+#include "mav/DirectIO.h"
+
+using namespace mav;
+
+
+TEST_CASE("Direct IO") {
+    MessageSet message_set;
+    message_set.addFromXMLString(R"(
+        <mavlink>
+            <messages>
+                <message id="0" name="HEARTBEAT">
+                    <field type="uint8_t" name="type">Type of the MAV (quadrotor, helicopter, etc., up to 15 types, defined in MAV_TYPE ENUM)</field>
+                    <field type="uint8_t" name="autopilot">Autopilot type / class. defined in MAV_AUTOPILOT ENUM</field>
+                    <field type="uint8_t" name="base_mode">System mode bitfield, see MAV_MODE_FLAGS ENUM in mavlink/include/mavlink_types.h</field>
+                    <field type="uint32_t" name="custom_mode">A bitfield for use for autopilot-specific flags.</field>
+                    <field type="uint8_t" name="system_status">System status flag, see MAV_STATE ENUM</field>
+                    <field type="uint8_t" name="mavlink_version">MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version</field>
+                </message>
+            </messages>
+        </mavlink>
+    )");
+    message_set.addFromXMLString(R""""(
+    <mavlink>
+        <messages>
+            <message id="9915" name="BIG_MESSAGE">
+                <field type="uint8_t" name="uint8_field">description</field>
+                <field type="int8_t" name="int8_field">description</field>
+                <field type="uint16_t" name="uint16_field">description</field>
+                <field type="int16_t" name="int16_field">description</field>
+                <field type="uint32_t" name="uint32_field">description</field>
+                <field type="int32_t" name="int32_field">description</field>
+                <field type="uint64_t" name="uint64_field">description</field>
+                <field type="int64_t" name="int64_field">description</field>
+                <field type="double" name="double_field">description</field>
+                <field type="float" name="float_field">description</field>
+                <field type="char[20]" name="char_arr_field">description</field>
+                <field type="float[3]" name="float_arr_field">description</field>
+                <field type="int32_t[3]" name="int32_arr_field">description</field>
+                <extensions/>
+                <field type="uint8_t" name="extension_uint8_field">description</field>
+            </message>
+        </messages>
+    </mavlink>
+    )"""");
+
+    REQUIRE(message_set.contains("BIG_MESSAGE"));
+    REQUIRE_EQ(message_set.size(), 2);
+
+    SUBCASE("Can connect server client") {
+
+        // setup client
+        auto heartbeat = message_set.create("HEARTBEAT")({
+            {"type", 1},
+            {"autopilot", 2},
+            {"base_mode", 3},
+            {"custom_mode", 4},
+            {"system_status", 5},
+            {"mavlink_version", 6}});
+
+        // setup server
+        uint8_t seq = 0;
+
+        mav::Identifier identifier{42, 99};
+        mav::DirectIO server_physical(
+            nullptr,
+            [&](uint8_t* buf, uint32_t len) {
+                if (seq > 0) {
+                    std::cout << "done" <<std::endl;
+                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                    return static_cast<ssize_t>(0);
+                }
+
+                ssize_t size = heartbeat.finalize(seq++, identifier);
+                if (size <= len) {
+                    std::cout << "memcpy" <<std::endl;
+                    std::memcpy(buf, heartbeat.data(), size);
+                    return size;
+                } else {
+                    return static_cast<ssize_t>(-1);
+                }
+            });
+        mav::NetworkRuntime server_runtime(message_set, server_physical);
+
+        std::array<uint8_t, 1024> buffer;
+        auto received_message = server_physical.receive(buffer.data(), buffer.size());
+        // TODO: never reached
+        std::cout << "Received!" << std::endl;
+    }
+}
+


### PR DESCRIPTION
The aim is to add a network interface which can be serviced just using two callbacks. Something like that would allow libmav to be integrated into MAVSDK.

The current implementation seems to hang somewhere and never actually move on. I'm not sure yet why. Any hints would be most welcome.