### PR TITLE
Update README.md - consumption of messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ auto response = connection.receive(expecation, 1000);
 
 #### Receive using a callback
 
-Alternatively, you can also register regular callbacks
+Alternatively, you can also register regular callbacks.
+Note however that this will consume all messages, effectively disabling the synchronous APIs. 
 
 ```C++
 // adding a callback


### PR DESCRIPTION
@ThomasDebrunner In libmav-python if you start the async callbacks then any sync receives do not work - with expectation or directly. My assumption is that the async callbacks consume any messages you might otherwise get.

Slightly worse, the timeouts don't appear to work either - freezing the terminal forever.

Now this could be libmav-python oddity, but I am assuming not, so have posted here for "discussion".