### PR TITLE
gcc: Enable -Wall and -Wextra for test build. Fix issues in library

### DIFF
--- a/include/mav/Message.h
+++ b/include/mav/Message.h
@@ -87,10 +87,10 @@ namespace mav {
 
         Message(const MessageDefinition &message_definition, ConnectionPartner source_partner, int crc_offset,
                 std::array<uint8_t, MessageDefinition::MAX_MESSAGE_SIZE> &&backing_memory) :
-                _message_definition(&message_definition),
                 _source_partner(source_partner),
-                _crc_offset(crc_offset),
-                _backing_memory(std::move(backing_memory)) {}
+                _backing_memory(std::move(backing_memory)),
+                _message_definition(&message_definition),
+                _crc_offset(crc_offset) {}
 
         inline bool isFinalized() const {
             return _crc_offset >= 0;
@@ -295,7 +295,7 @@ namespace mav {
                 throw std::invalid_argument(StringFormat() << "Field " << field_key <<
                                                         " is not of type char" << StringFormat::end);
             }
-            if (v.size() > field.type.size) {
+            if (static_cast<int>(v.size()) > field.type.size) {
                 throw std::out_of_range(StringFormat() << "String of length " << v.size() <<
                                                        " does not fit in field with size " << field.type.size <<
                                                        StringFormat::end);
@@ -327,7 +327,7 @@ namespace mav {
                     ret_value.resize(field.type.size);
                 }
 
-                if (ret_value.size() < field.type.size) {
+                if (static_cast<int>(ret_value.size()) < field.type.size) {
                     throw std::out_of_range(StringFormat() << "Array of size " << field.type.size <<
                         " can not fit in return type of size " << ret_value.size() << StringFormat::end);
                 }

--- a/include/mav/Network.h
+++ b/include/mav/Network.h
@@ -80,7 +80,7 @@ namespace mav {
         virtual ConnectionPartner receive(uint8_t* destination, uint32_t size) = 0;
         virtual void markMessageBoundary() {};
         virtual void markSyncing() {};
-        virtual bool isConnectionOriented() const {
+        [[nodiscard]] virtual bool isConnectionOriented() const {
             return false;
         };
     };
@@ -289,8 +289,8 @@ namespace mav {
         NetworkRuntime(const Identifier &own_id, const MessageSet &message_set, NetworkInterface &interface,
                        std::function<void(const std::shared_ptr<Connection>&)> on_connection = {},
                        std::function<void(const std::shared_ptr<Connection>&)> on_connection_lost = {}) :
-                _own_id(own_id), _message_set(message_set),
-                _interface(interface), _parser(_message_set, _interface),
+                _interface(interface), _message_set(message_set),
+                _parser(_message_set, _interface), _own_id(own_id),
                 _on_connection(std::move(on_connection)), _on_connection_lost(std::move(on_connection_lost)) {
 
             _receive_thread = std::thread{

--- a/include/mav/UDPClient.h
+++ b/include/mav/UDPClient.h
@@ -57,7 +57,7 @@ namespace mav {
         struct sockaddr_in _server_address{};
 
         std::array<uint8_t, RX_BUFFER_SIZE> _rx_buffer;
-        int _bytes_available = 0;
+        uint32_t _bytes_available = 0;
         ConnectionPartner _partner;
 
     public:
@@ -119,7 +119,7 @@ namespace mav {
             return _partner;
         }
 
-        void send(const uint8_t *data, uint32_t size, ConnectionPartner target) override {
+        void send(const uint8_t *data, uint32_t size, ConnectionPartner) override {
             // no need to specify target here, as we called the udp connect function in constructor
             if (sendto(_socket, data, size, 0, (struct sockaddr *) nullptr, 0) < 0) {
                 ::close(_socket);

--- a/include/mav/UDPServer.h
+++ b/include/mav/UDPServer.h
@@ -56,7 +56,7 @@ namespace mav {
         int _socket = -1;
 
         std::array<uint8_t, RX_BUFFER_SIZE> _rx_buffer;
-        int _bytes_available = 0;
+        uint32_t _bytes_available = 0;
         ConnectionPartner _current_partner;
 
     public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(tests
 
 add_test(NAME tests COMMAND tests)
 
-target_compile_options(tests PRIVATE -O0 -g --coverage)
+target_compile_options(tests PRIVATE -O0 -g --coverage -Wall -Wextra -pedantic)
 target_link_options(tests PRIVATE --coverage)
 target_include_directories(tests PRIVATE ../include)
 target_link_libraries(tests PRIVATE Threads::Threads)

--- a/tests/TCP.cpp
+++ b/tests/TCP.cpp
@@ -48,7 +48,7 @@ TEST_CASE("TCP server client") {
 
         std::promise<void> connection_called_promise;
         auto connection_called_future = connection_called_promise.get_future();
-        server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection> &connection) {
+        server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection>&) {
             connection_called_promise.set_value();
         });
 

--- a/tests/UDP.cpp
+++ b/tests/UDP.cpp
@@ -61,7 +61,7 @@ TEST_CASE("UDP server client") {
 
         std::promise<void> connection_called_promise;
         auto connection_called_future = connection_called_promise.get_future();
-        server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection> &connection) {
+        server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection>&) {
             connection_called_promise.set_value();
         });
 


### PR DESCRIPTION
This enables `-Wall` and `-Wextra` to the test build target, as well as fixes all issues that come from the core library header files. There are still some minor unresolved issues in the tests themselves. 