### PR TITLE
Fix corner case in decoding when truncation is active

### DIFF
--- a/include/mav/utils.h
+++ b/include/mav/utils.h
@@ -84,12 +84,16 @@ namespace mav {
 
 
     template <typename T>
-    inline T deserialize(const uint8_t* source, uint32_t deserialize_size) {
+    inline T deserialize(const uint8_t* source, int deserialize_size) {
+        // in case we do not have any bytes to read, we return 0
+        if (deserialize_size <= 0) {
+            return T{0};
+        }
         if (deserialize_size == sizeof(T)) {
             return *static_cast<const T*>(static_cast<const void*>(source));
         } else {
             uint8_t deserialize_buff[sizeof(T)]{};
-            std::copy(source, source + std::min(deserialize_size, static_cast<uint32_t>(sizeof(T))), deserialize_buff);
+            std::copy(source, source + std::min(static_cast<uint32_t>(deserialize_size), static_cast<uint32_t>(sizeof(T))), deserialize_buff);
             return *static_cast<const T*>(static_cast<const void*>(deserialize_buff));
         }
     }


### PR DESCRIPTION
This fixes an edge case, where

- There is a single byte value (uint8, int8)
- It is set to zero
- It lies at the end of the message, after it everything is set to zero
- Because of this, zero elicion kicks in
- Exactly one byte before the value in question is also zero (either higher bytes of a multi byte value, or another zero one-byte value)
- -> In this case, the value in question will lay exactly on the second byte of the CRC
- The decoding logic would figure out, that it can read exactly -1 bytes from the underlying buffer (or 0, realistically)
- Due to a coding issue, this value was implicitly converted to an unsigned integer, leading to a large value
- Since that value was bigger than sizeof(uint8_t), the logic read exactly one byte from the underlying buffer at that position, which ended up being the second digit of the CRC.


Note that the error also existed for other values, but:
- If the value is on the first byte of the CRC, the logic reads exactly 0 bytes, which then gets interpreted as 0.
- If the value is after the second byte of the CRC, it is in a zero-initialized buffer, also evaluating as zero.
So while the program error was there, it was only visible in this specific case.


This PR adds a unit test and the fix, which is to always return value 0 when trying to read a negative or zero amount of bytes. 