### PR TITLE
QGC-Gov fixes - Add a timeout argument to TCPClient

### DIFF
--- a/include/mav/TCPClient.h
+++ b/include/mav/TCPClient.h
@@ -55,10 +55,17 @@ namespace mav {
 
     public:
 
-        TCPClient(const std::string& address, int port) {
+        TCPClient(const std::string& address, int port, int timeout = -1) {
             _socket = socket(AF_INET, SOCK_STREAM, 0);
             if (_socket < 0) {
                 throw NetworkError("Could not create socket", errno);
+            }
+
+            if (timeout > 0) {
+                struct timeval send_timeout;
+                send_timeout.tv_sec = 0;
+                send_timeout.tv_usec = timeout;
+                setsockopt(_socket, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
             }
 
             struct hostent *hp;


### PR DESCRIPTION
I'll be PR'ing a few changes that we've made in a branch for use with QGC-Gov. We've been using these successfully for several months and had successful flight test events on this code, so I think we're good to get these merged in.

**Add a timeout argument to TCPClient**

_Background_ -- In QGC-Gov, one of our programs has a use case for libmav which involves setting up and tearing down connections to vehicles on-demand. Most of the time, vehicle control is handled by an external autonomy engine, but if the user requests manual control of the vehicle, the autonomy engine opens up direct link to the vehicle and we can send messages. Due to the fact that this can happen repeatedly, plus a number of edge cases such as the autonomy engine re-taking control, or either side unexpected breaking the link or rebooting, it is feasible that the link doesn't get properly torn down and we were ending up with instances where the operating system was still holding the old socket open and not allowing a new connection to be made (socket in use error). Some cursory research shows that socket seem to be able to be held for several minutes by default. 

So here, we simply add a option to specify a specific timeout when setting up the link. This has solved our problems.