### PR TITLE
Allow arbitrary functional selector for expectation

### DIFF
--- a/include/mav/Connection.h
+++ b/include/mav/Connection.h
@@ -250,6 +250,10 @@ namespace mav {
         Message inline receive(int message_id, int timeout_ms=-1) {
             return receive(message_id, mav::ANY_ID, mav::ANY_ID, timeout_ms);
         }
+
+        Message inline receive(std::function<bool(const mav::Message&)> selector, int timeout_ms=-1) {
+            return receive(expect(std::move(selector)), timeout_ms);
+        }
     };
 
 };


### PR DESCRIPTION
This adds the following expectaction prototype:

```
Expectation expect(std::function<bool(const mav::Message&)> selector)
```

Which can be used for specifc queries, e.g. 

```
auto expectation = connection.expect([](const mav::Message &message) {
   return message.id() == 11232 && message["field3"].as<int>() == 15;
})

auto message = connection.receive(expectation);
```

The current `expect` functions 

```
Expectation expect(int message_id, int source_id=mav::ANY_ID, int component_id=mav::ANY_ID)
Expectation expect(const std::string &message_name, int source_id=mav::ANY_ID, int component_id=mav::ANY_ID)
```

Have been changed to be specializations of the more generic `expect` function with the funcional argument


This also adds a new `receive` prototype:

```
Message inline receive(std::function<bool(const mav::Message&)> selector, int timeout_ms=-1)
```
Which again gives the user the possibility to receive a very specific message. This also makes use of the new `expect` function.