### PR TITLE
Send a message directly on NetworkRuntime

### DIFF
--- a/include/mav/Network.h
+++ b/include/mav/Network.h
@@ -405,6 +405,10 @@ namespace mav {
             _heartbeat_message = std::nullopt;
         }
 
+        void sendMessage(Message &message) {
+            _sendMessage(message, {});
+        }
+
         void stop() {
             _interface.close();
             _should_terminate.store(true);

--- a/include/mav/Network.h
+++ b/include/mav/Network.h
@@ -405,7 +405,7 @@ namespace mav {
             _heartbeat_message = std::nullopt;
         }
 
-        void sendMessage(Message &message) {
+        void injectMessage(Message &message) {
             _sendMessage(message, {});
         }
 


### PR DESCRIPTION
Add a means to send a message directly on a network runtime without need for a connection object.

Quoting Thomas here as I initially forgot about this change and had it lumped into another PR

> What's this for?
> Generally, the NetworkInterface shouldn't be the interface for sending Messages, the Connection Object should be it. Directly sending messages on the Network Interface with default constructed ConnectionPartner would mean broadcasting a message to all known clients - a feature we probably don't want in the public API as it is an anti-pattern except for HEARTBEAT.

Generally I agree with you, and what I'm doing here is definitely not the preferred use. However, we have a program where the majority of the MAVLink messaging is done by a third-party autonomy engine (a completely separate piece of hardware on the network). But in case the user wants to do direct manual control from our GCS, we have a way to tell the autonomy engine to open a link to the vehicle and we can send out manual control messages (technically it'll forward any message, but manual control is the intended use). The link basically operates as a repeater and its only one way, so we don't get any data back. This means no heartbeats, and a Connection is useless because it will time out for lack of heartbeats. 

Open to exploring other way to solve this problem if you have suggestions, but this seemed the simplest to me.