### PR TITLE
Fix StringFormat for GCC 9

### DIFF
--- a/include/mav/utils.h
+++ b/include/mav/utils.h
@@ -116,7 +116,9 @@ namespace mav {
         static constexpr formatEndType end{};
         static constexpr formatEndType toString{};
 
+#if __GNUC__ > 9
         StringFormat() noexcept = default;
+#endif
 
         template <typename T>
         StringFormat& operator<< (const T &value) noexcept {


### PR DESCRIPTION
After rebasing some of my other PRs on the latest main, I am no longer able to build. I get the error copied below.

It appears this was introduced to libmav in 00620a9 and stems from the fact that we're building on Ubuntu 20.04 and thus we use gcc 9. CI uses ubuntu-latest, which is 22.04, which is gcc 11. There appears to be some online discussion about the particular behavior causing this, and as far as I can tell it boils down to differences between cpp versions and compiler implementations for the different cpp standards. Anyway, we're required to use Ubuntu 20.04 as that is the latest approved for US government programs, so we need this to work for us.

Let me know if you'd prefer another way of working around this issue.

```
In file included from /home/stuart/Git/libmav/tests/../include/mav/MessageSet.h:41,
                 from /home/stuart/Git/libmav/tests/MessageSet.cpp:6:
/home/stuart/Git/libmav/tests/../include/mav/MessageDefinition.h: In member function ‘const mav::Field& mav::MessageDefinition::fieldForName(const string&) const’:
/home/stuart/Git/libmav/tests/../include/mav/MessageDefinition.h:337:54: error: use of deleted function ‘mav::StringFormat::StringFormat()’
  337 |                 throw std::out_of_range(StringFormat() << "Field \"" << field_key << "\" does not exist in message "
      |                                                      ^
In file included from /home/stuart/Git/libmav/tests/../include/mav/MessageDefinition.h:42,
                 from /home/stuart/Git/libmav/tests/../include/mav/MessageSet.h:41,
                 from /home/stuart/Git/libmav/tests/MessageSet.cpp:6:
/home/stuart/Git/libmav/tests/../include/mav/utils.h:120:9: note: ‘mav::StringFormat::StringFormat() noexcept’ is implicitly deleted because its exception-specification does not match the implicit exception-specification ‘’
  120 |         StringFormat() noexcept = default;
      |         ^~~~~~~~~~~~

```