### PR TITLE
Add Ubuntu 20 to CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
             platform:
               - runner: ubuntu-latest
                 sonarcloud-build-wrapper : build-wrapper-linux-x86-64
+              - runner: ubuntu-20.04
+                sonarcloud-build-wrapper : build-wrapper-linux-x86-64
               - runner: macos-latest
                 sonarcloud-build-wrapper : build-wrapper-macosx-x86
     runs-on: ${{ matrix.platform.runner }}


### PR DESCRIPTION
I just added Ubuntu 20 to the platforms we run CI on. There doesn't appear to be a need to modify any test steps other than that. I also checked it on a branch without the previous GCC 9 fix and indeed that run failed as expected.