### PR TITLE
Address warnings

### DIFF
--- a/include/mav/Connection.h
+++ b/include/mav/Connection.h
@@ -272,7 +272,7 @@ namespace mav {
         }
     };
 
-};
+}
 
 
 #endif //MAV_CONNECTION_H

--- a/include/mav/Message.h
+++ b/include/mav/Message.h
@@ -289,10 +289,12 @@ namespace mav {
             auto field = _message_definition->fieldForName(field_key);
 
             if constexpr(is_string<T>::value) {
+                (void)array_index; // unused
                 setFromString(field_key, v);
             }
 
             else if constexpr(is_iterable<T>::value) {
+                (void)array_index; // unused
                 auto begin = std::begin(v);
                 auto end = std::end(v);
                 if ((end - begin) > field.type.size) {
@@ -387,8 +389,10 @@ namespace mav {
         template <typename T>
         [[nodiscard]] T getAsFloatUnpack(const std::string &field_key, int array_index = 0) const {
             if constexpr(is_string<T>::value) {
+                (void)array_index; // unused
                 throw std::runtime_error("Cannot do float unpack to a string");
             } else if constexpr(is_iterable<T>::value) {
+                (void)array_index; // unused
                 throw std::runtime_error("Cannot do float unpack to an iterable");
             } else {
                 return floatUnpack<T>(get<float>(field_key, array_index));

--- a/include/mav/TCPServer.h
+++ b/include/mav/TCPServer.h
@@ -163,7 +163,7 @@ namespace mav {
         }
 
         ConnectionPartner receive(uint8_t *destination, uint32_t size) override {
-            int bytes_received = 0;
+            uint32_t bytes_received = 0;
 
             while (bytes_received < size) {
 
@@ -188,7 +188,7 @@ namespace mav {
                     ConnectionPartner partner_to_read_from;
 
                     // iterate through the activity
-                    for (int i = 0; i < _poll_fds.size(); i++) {
+                    for (size_t i = 0; i < _poll_fds.size(); i++) {
                         if (_poll_fds[i].revents == 0) {
                             continue;
                         }

--- a/tests/Message.cpp
+++ b/tests/Message.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Message set creation") {
     SUBCASE("Have fields truncated by zero-elision") {
         message.set("int64_field", 34); // since largest field, will be at the end of the message
         CHECK_EQ(message.get<int64_t>("int64_field"), 34);
-        auto ret = message.finalize(1, {2, 3});
+        (void)message.finalize(1, {2, 3});
         CHECK_EQ(message.get<int64_t>("int64_field"), 34);
     }
 
@@ -247,7 +247,7 @@ TEST_CASE("Message set creation") {
         message.set("float_arr_field", std::vector<float>{0.0, 0.0, 0.0});
         message.set("int32_arr_field", std::vector<int32_t>{0, 0, 0});
 
-        int wire_size = message.finalize(5, {6, 7});
+        (void)message.finalize(5, {6, 7});
         CHECK_EQ(message.get<std::string>("char_arr_field"), "Hello World!");
 
         // check that it stays correct even after modifying the fields
@@ -387,8 +387,8 @@ TEST_CASE("Message set creation") {
 
         // Attempt to access signature before signed (const & non-const versions)
         const auto const_message = message_set.create("UINT8_ONLY_MESSAGE");
-        CHECK_THROWS_AS(message.signature(), std::runtime_error);
-        CHECK_THROWS_AS(const_message.signature(), std::runtime_error);
+        CHECK_THROWS_AS((void)message.signature(), std::runtime_error);
+        CHECK_THROWS_AS((void)const_message.signature(), std::runtime_error);
 
         uint32_t wire_size = message.finalize(5, {6, 7}, key, timestamp);
 

--- a/tests/Network.cpp
+++ b/tests/Network.cpp
@@ -182,21 +182,21 @@ TEST_CASE("Create network runtime") {
         interface.reset();
         auto expectation = connection->expect("TEST_MESSAGE");
         interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xd9"s, interface_wrong_partner);
-        CHECK_THROWS_AS(auto message = connection->receive(expectation, 100), TimeoutException);
+        CHECK_THROWS_AS((void)connection->receive(expectation, 100), TimeoutException);
     }
 
     SUBCASE("Can not receive message with CRC error") {
         interface.reset();
         auto expectation = connection->expect("TEST_MESSAGE");
         interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xda"s, interface_partner);
-        CHECK_THROWS_AS(auto message = connection->receive(expectation, 100), TimeoutException);
+        CHECK_THROWS_AS((void)connection->receive(expectation, 100), TimeoutException);
     }
 
     SUBCASE("Can not receive message with unknown message ID") {
         interface.reset();
         auto expectation = connection->expect(9912);
         interface.addToReceiveQueue("\xfd\x04\x00\x00\x00\x01\x01\xb8\x26\x00\xcd\xcc\x54\x41\x59\x8e"s, interface_partner);
-        CHECK_THROWS_AS(auto message = connection->receive(expectation, 100), TimeoutException);
+        CHECK_THROWS_AS((void)connection->receive(expectation, 100), TimeoutException);
     }
 
     SUBCASE("Receive throws a NetworkError if the interface fails, error callback gets called") {
@@ -206,6 +206,7 @@ TEST_CASE("Create network runtime") {
         auto error_callback_called_promise = std::promise<void>();
         connection->addMessageCallback([](const Message &message) {
            // do nothing
+           (void)message;
         }, [&error_callback_called_promise](const std::exception_ptr& exception) {
             error_callback_called_promise.set_value();
             CHECK_THROWS_AS(std::rethrow_exception(exception), NetworkError);
@@ -214,7 +215,7 @@ TEST_CASE("Create network runtime") {
         auto expectation = connection->expect("TEST_MESSAGE");
         interface.makeFailOnNextReceive();
         // Receive on the sync api. The receive should then throw an exception
-        CHECK_THROWS_AS(auto message = connection->receive(expectation), NetworkError);
+        CHECK_THROWS_AS((void)connection->receive(expectation), NetworkError);
         CHECK((error_callback_called_promise.get_future().wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
         connection->removeAllCallbacks();
     }
@@ -223,7 +224,7 @@ TEST_CASE("Create network runtime") {
         interface.reset();
         auto expectation = connection->expect("HEARTBEAT");
         interface.makeFailOnNextReceive();
-        CHECK_THROWS_AS(auto message = connection->receive(expectation), NetworkError);
+        CHECK_THROWS_AS((void)connection->receive(expectation), NetworkError);
         CHECK_FALSE(connection->alive());
         interface.reset();
         expectation = connection->expect("HEARTBEAT");
@@ -299,7 +300,7 @@ TEST_CASE("Create network runtime") {
         interface.reset();
         for (int i = 0; i < 10; i++) {
             auto expectation = connection->expect("TEST_MESSAGE");
-            CHECK_THROWS_AS(auto message = connection->receive(expectation, 100), TimeoutException);
+            CHECK_THROWS_AS((void)connection->receive(expectation, 100), TimeoutException);
         }
         // send a heartbeat. Any message will clear expired expectations
         interface.addToReceiveQueue("\xfd\x09\x00\x00\x00\xfd\x01\x00\x00\x00\x04\x00\x00\x00\x01\x02\x03\x05\x06\x77\x53"s, interface_partner);

--- a/tests/TCP.cpp
+++ b/tests/TCP.cpp
@@ -102,7 +102,7 @@ TEST_CASE("TCP server client") {
                                                                   {"mavlink_version", 6}});
 
             std::promise<std::shared_ptr<mav::Connection>> connection2_promise;
-            server_runtime.onConnection([&heartbeat2, &connection2_promise](const std::shared_ptr<mav::Connection> &connection) {
+            server_runtime.onConnection([&connection2_promise](const std::shared_ptr<mav::Connection> &connection) {
                 connection2_promise.set_value(connection);
             });
 

--- a/tests/UDP.cpp
+++ b/tests/UDP.cpp
@@ -140,6 +140,7 @@ TEST_CASE("UDP server client") {
         std::promise<void> connection_called_promise;
         auto connection_called_future = connection_called_promise.get_future();
         server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection> &connection) {
+            (void)connection;
             connection_called_promise.set_value();
         });
 
@@ -163,6 +164,7 @@ TEST_CASE("UDP server client") {
         std::promise<void> connection_dropped_promise;
         auto connection_dropped_future = connection_dropped_promise.get_future();
         client_runtime.onConnectionLost([&connection_dropped_promise](const std::shared_ptr<mav::Connection> &connection) {
+            (void)connection;
             connection_dropped_promise.set_value();
         });
 
@@ -200,6 +202,7 @@ TEST_CASE("UDP server client") {
         std::promise<void> connection_called_promise;
         auto connection_called_future = connection_called_promise.get_future();
         server_runtime.onConnection([&connection_called_promise](const std::shared_ptr<mav::Connection> &connection) {
+            (void)connection;
             connection_called_promise.set_value();
         });
 
@@ -229,6 +232,7 @@ TEST_CASE("UDP server client") {
             std::promise<void> connection_dropped_promise;
             auto connection_dropped_future = connection_dropped_promise.get_future();
             client_runtime.onConnectionLost([&connection_dropped_promise](const std::shared_ptr<mav::Connection> &connection) {
+                (void)connection;
                 connection_dropped_promise.set_value();
             });
 


### PR DESCRIPTION
Address warnings in libmav includes and in the tests as well. Just trying to clean things up since the warnings from the includes here were creating quite a verbose build log when using libmav in QGC-Gov.

Most of the warnings were just unused variables.

Tested locally with GCC 9 on Ubuntu 20.04, and I also addressed a warning that only showed up on MacOS in the CI build log. [Build log before](https://github.com/Auterion/libmav/actions/runs/8099120839/job/22134137741#step:6:1) / [Build log after](https://github.com/Auterion/libmav/actions/runs/8236817236/job/22524137356#step:6:1)
