### PR TITLE
connection: added a more intelligent callback API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
                 sonarcloud-build-wrapper : build-wrapper-linux-x86-64
               - runner: ubuntu-20.04
                 sonarcloud-build-wrapper : build-wrapper-linux-x86-64
-              - runner: macos-latest
+              - runner: macos-13
                 sonarcloud-build-wrapper : build-wrapper-macosx-x86
     runs-on: ${{ matrix.platform.runner }}
     steps:

--- a/include/mav/Connection.h
+++ b/include/mav/Connection.h
@@ -193,7 +193,7 @@ namespace mav {
         }
 
         CallbackHandle addMessageCallback(const std::function<void(const mav::Message&)> &on_message,
-                                          const std::function<void(const std::exception_ptr&)> on_error) {
+                                          const std::function<void(const std::exception_ptr&)> &on_error) {
             std::scoped_lock<std::mutex> lock(_message_callback_mtx);
             CallbackHandle handle = _next_handle;
             _message_callbacks[handle] = FunctionCallback{on_message, on_error};
@@ -215,7 +215,7 @@ namespace mav {
             }, on_error);
         }
 
-        CallbackHandle addMessageCallback(int message_id, std::function<void(const mav::Message&)> on_message,
+        CallbackHandle addMessageCallback(int message_id, const std::function<void(const mav::Message&)> &on_message,
                                           int source_id=mav::ANY_ID, int component_id=mav::ANY_ID) {
             return addMessageCallback([message_id, source_id, component_id](const Message &message) {
                 return message.id() == message_id &&
@@ -224,7 +224,7 @@ namespace mav {
             }, on_message, std::function<void(const std::exception_ptr&)>{});
         }
 
-        CallbackHandle addMessageCallback(const std::string &message_name, std::function<void(const mav::Message&)> on_message,
+        CallbackHandle addMessageCallback(const std::string &message_name, const std::function<void(const mav::Message&)> &on_message,
                                           int source_id=mav::ANY_ID, int component_id=mav::ANY_ID) {
             return addMessageCallback(_message_set.idForMessage(message_name), on_message, source_id, component_id);
         }

--- a/tests/Network.cpp
+++ b/tests/Network.cpp
@@ -94,7 +94,7 @@ uint64_t getTimestamp() {
     return 770479200;
 }
 
-TEST_CASE("Create network runtime") {
+TEST_CASE("Network runtime") {
 
     MessageSet message_set;
     message_set.addFromXMLString(R"(
@@ -153,6 +153,24 @@ TEST_CASE("Create network runtime") {
         CHECK_EQ(message.name(), "TEST_MESSAGE");
         CHECK_EQ(message.get<int>("value"), 42);
         CHECK_EQ(message.get<std::string>("text"), "Hello World!");
+    }
+
+    SUBCASE("Selects correct message for specific message id, system id, component id") {
+        interface.reset();
+        auto expectation = connection->expect("TEST_MESSAGE", 1, 1);
+        // message with wrong system id
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x02\x01\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\xa0\xcb"s, interface_partner);
+        // message with wrong component id
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x01\x02\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\xe2\x61"s, interface_partner);
+        // message with wrong message id
+        interface.addToReceiveQueue("\xfd\x09\x00\x00\x00\xfd\x01\x00\x00\x00\x04\x00\x00\x00\x01\x02\x03\x05\x06\x77\x53"s, interface_partner);
+        // message with correct system id and component id and message id
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x01\x01\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x56\x38"s, interface_partner);
+        auto message = connection->receive(expectation);
+        // we should only have received the last message
+        CHECK_EQ(message.name(), "TEST_MESSAGE");
+        CHECK_EQ(message.header().systemId(), 1);
+        CHECK_EQ(message.header().componentId(), 1);
     }
 
 
@@ -322,6 +340,44 @@ TEST_CASE("Create network runtime") {
 
         interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xd9"s, interface_partner);
         CHECK((callback_called_future.wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+        connection->removeAllCallbacks();
+    }
+
+    SUBCASE("Can specify message callbacks for message id, source system id and source component id") {
+        interface.reset();
+
+        // these should not get called
+        connection->addMessageCallback(9916, [](const Message &message) {
+            FAIL("This callback should not be called");
+        }, 1, 2);
+
+        connection->addMessageCallback(9916, [](const Message &message) {
+            FAIL("This callback should not be called");
+        }, 2, 1);
+
+        connection->addMessageCallback(9917, [](const Message &message) {
+            FAIL("This callback should not be called");
+        }, 1, 1);
+
+        // run a send-receive twice - if we succeed the second time around, we know for sure that the FAIL were not
+        // called from the first time around, since there is only a single receive thread.
+        for (int i=0; i<2; i++) {
+            std::promise<void> callback_called_promise;
+            auto callback_called_future = callback_called_promise.get_future();
+
+
+            // this should get called
+            auto cb = connection->addMessageCallback(9916, [&callback_called_promise](const Message &message) {
+                if (message.name() == "TEST_MESSAGE") {
+                    callback_called_promise.set_value();
+                }
+            }, 1, 1);
+
+            // message id is 9916, source system id is 1, source component id is 1
+            interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x01\x01\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x56\x38"s, interface_partner);
+            CHECK((callback_called_future.wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+            connection->removeMessageCallback(cb);
+        }
         connection->removeAllCallbacks();
     }
 }


### PR DESCRIPTION
This allows to filter for message ID, system ID and component ID when registerin callbacks like so:
```
        connection->addMessageCallback("TEST_MESSAGE", [&callback_called_promise](const Message &message) {
           // do something
        });
```