### PR TITLE
Add a timeout argument to TCPClient

### DIFF
--- a/include/mav/TCPClient.h
+++ b/include/mav/TCPClient.h
@@ -55,10 +55,17 @@ namespace mav {
 
     public:
 
-        TCPClient(const std::string& address, int port) {
+        TCPClient(const std::string& address, int port, int timeout = -1) {
             _socket = socket(AF_INET, SOCK_STREAM, 0);
             if (_socket < 0) {
                 throw NetworkError("Could not create socket", errno);
+            }
+
+            if (timeout > 0) {
+                struct timeval send_timeout;
+                send_timeout.tv_sec = 0;
+                send_timeout.tv_usec = timeout * 1000; // timeout is in ms
+                setsockopt(_socket, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
             }
 
             struct hostent *hp;


### PR DESCRIPTION
Essentially I'm re-making #29. Finally tracked down a reproducible cause for this. [Refer to thread here.](https://github.com/Auterion/qgc-gov/pull/936) I'll be honest, I'm not an expert on Unix sockets, and don't entirely understand why, but something here is getting help open and blocking. Its clearly blocking something in the sockets layer because our application code that calls this is already in an independent thread and shouldn't care if that application thread itself is blocked.

Regardless, the timeout I added is an optional argument that shouldn't affect anything if it isn't used.