### PR TITLE
UDP: do not discard bytes in rx_buffer at start of receive

### DIFF
--- a/include/mav/UDPClient.h
+++ b/include/mav/UDPClient.h
@@ -99,9 +99,7 @@ namespace mav {
         ConnectionPartner receive(uint8_t *destination, uint32_t size) override {
             // Receive as many messages as needed to have enough bytes available (none if already enough bytes)
             while (_bytes_available < size && !_should_terminate.load()) {
-                // If there are residual bytes from last packet, but not enough for parsing new packet, clear out
-                _bytes_available = 0;
-                ssize_t ret = ::recvfrom(_socket, _rx_buffer.data(), RX_BUFFER_SIZE, 0,
+                ssize_t ret = ::recvfrom(_socket, _rx_buffer.data() + _bytes_available, RX_BUFFER_SIZE - _bytes_available, 0,
                                          (struct sockaddr *) nullptr, nullptr);
                 if (ret < 0) {
                     throw NetworkError("Could not receive from socket", errno);

--- a/include/mav/UDPServer.h
+++ b/include/mav/UDPServer.h
@@ -107,11 +107,9 @@ namespace mav {
         ConnectionPartner receive(uint8_t *destination, uint32_t size) override {
             // Receive as many messages as needed to have enough bytes available (none if already enough bytes)
             while (_bytes_available < size && !_should_terminate.load()) {
-                // If there are residual bytes from last packet, but not enough for parsing new packet, clear out
-                _bytes_available = 0;
                 struct sockaddr_in source_address{};
                 socklen_t source_address_length = sizeof(source_address);
-                ssize_t ret = ::recvfrom(_socket, _rx_buffer.data(), RX_BUFFER_SIZE, 0,
+                ssize_t ret = ::recvfrom(_socket, _rx_buffer.data() + _bytes_available, RX_BUFFER_SIZE - _bytes_available, 0,
                                      (struct sockaddr*)&source_address, &source_address_length);
                 if (ret < 0) {
                     throw NetworkError("Could not receive from socket", errno);


### PR DESCRIPTION
Problem:
There was an issue with the UDP server implementation (same for the client) when a connected UDP client was not sending proper mavlink v2 message. After accidentally receiving the mavlink v2 magic starter byte, it tried to receive the rest of the message. Parsing the mavlink header was fine, but the payload length could end up being the max value. The receive function is then blocked in here: https://github.com/Auterion/libmav/blob/main/include/mav/UDPServer.h#L109
Where it tries to receive data from the UDP socket until it finds a datagram which is larger than the requested read size, while discarding smaller datagrams.

Solution:
Do not discard the bytes in the RX_buffer when a new read from the datagram is requested. it makes no sense to discard bytes after the starter byte has been found. Instead accumulate them in the buffer until the size is reached. This way at least it can get out of the receive function on garbage data. Buffer is still flushed on the markSync call.