### PR TITLE
Update Ubuntu version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
             platform:
               - runner: ubuntu-latest
                 sonarcloud-build-wrapper : build-wrapper-linux-x86-64
-              - runner: ubuntu-20.04
+              - runner: ubuntu-22.04
                 sonarcloud-build-wrapper : build-wrapper-linux-x86-64
               - runner: macos-13
                 sonarcloud-build-wrapper : build-wrapper-macosx-x86


### PR DESCRIPTION
Remove support for `ubuntu-20.04` as Github will be deprecating runners for it soon. Replace with `ubuntu-22.04` since `ubuntu-latest` now returns `ubuntu-24.04`.

Refer to https://github.com/actions/runner-images/issues/11101