### PR TITLE
Test: fix unused parameter warning

### DIFF
--- a/tests/Network.cpp
+++ b/tests/Network.cpp
@@ -376,15 +376,15 @@ TEST_CASE("Network runtime") {
         interface.reset();
 
         // these should not get called
-        connection->addMessageCallback(9916, [](const Message &message) {
+        connection->addMessageCallback(9916, [](const Message &/*message*/) {
             FAIL("This callback should not be called");
         }, 1, 2);
 
-        connection->addMessageCallback(9916, [](const Message &message) {
+        connection->addMessageCallback(9916, [](const Message &/*message*/) {
             FAIL("This callback should not be called");
         }, 2, 1);
 
-        connection->addMessageCallback(9917, [](const Message &message) {
+        connection->addMessageCallback(9917, [](const Message &/*message*/) {
             FAIL("This callback should not be called");
         }, 1, 1);
 


### PR DESCRIPTION
When building as a part of another project with sufficiently pedantic warnings, we get three of these: 

```
....../libmav/tests/Network.cpp:379:64: warning: unused parameter ‘message’ [-Wunused-parameter]
  379 |         connection->addMessageCallback(9916, [](const Message &message) {
      |                                                 ~~~~~~~~~~~~~~~^~~~~~~
```

Commenting out the parameter name fixes the warning.
