### PR TITLE
Use steady_clock to measure connection timeout

### DIFF
--- a/include/mav/utils.h
+++ b/include/mav/utils.h
@@ -100,13 +100,6 @@ namespace mav {
     }
 
 
-    inline uint64_t millis() noexcept {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
-    }
-
-
-
     class StringFormat {
     private:
         std::stringstream _stream;


### PR DESCRIPTION
The connection timeout in the connection class was using the `std::chrono::system_clock` which is not monotonic and susceptible to time jumps when system wall clock is adjusted, see here: https://en.cppreference.com/w/cpp/chrono/system_clock

This can lead to connection timeout incorrectly evaluated. `std::chrono::steady_clock` should be used instead, as it is not susceptible for wall clock adjustments and should be preferred for time duration measurements: https://en.cppreference.com/w/cpp/chrono/steady_clock

The PR changes are the following:

- Remove the `millis()` public method from utils
- Replace integer millisecond with `std::chrono::milliseconds` for a more explicit type
- Use `steady_clock` to sample timestamps to measure connection timeout