### PR TITLE
fix: repair CI pipeline and add missing nlohmann_json dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: Tests
 
 on:
-  - push
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build-test:
@@ -11,19 +14,55 @@ jobs:
         platform:
           - runner: ubuntu-latest
           - runner: ubuntu-22.04
-          - runner: macos-13
+          - runner: macos-latest
     runs-on: ${{ matrix.platform.runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Install gcovr
-        run: pip3 install gcovr
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev
 
-      - name: Build tests
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install nlohmann-json
+
+      - name: Configure
         run: cmake -B build -S .
 
-      - name: Build tests
+      - name: Build
         run: cmake --build build
 
-      - name: Run tests and coverage
-        run: ./build/tests/tests
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y nlohmann-json3-dev
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install gcovr
+        run: pip install gcovr
+
+      - name: Configure
+        run: cmake -B build -S .
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Generate coverage report
+        run: gcovr --xml-pretty -o build/coverage.xml build
+
+      - name: Coverage summary
+        run: gcovr build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,18 @@ include(GNUInstallDirs)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+find_package(nlohmann_json QUIET)
+if(NOT nlohmann_json_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
@@ -23,6 +35,7 @@ target_include_directories(
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_features(mav INTERFACE cxx_std_17)
+target_link_libraries(mav INTERFACE nlohmann_json::nlohmann_json)
 
 install(TARGETS mav
         EXPORT ${PROJECT_NAME}_Targets

--- a/include/mav/Message.h
+++ b/include/mav/Message.h
@@ -39,6 +39,7 @@
 #include <array>
 #include <utility>
 #include <variant>
+#include <iostream>
 
 #include <nlohmann/json.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,5 +12,4 @@ add_test(NAME tests COMMAND tests)
 
 target_compile_options(tests PRIVATE -O0 -g --coverage -Wall -Wextra -pedantic)
 target_link_options(tests PRIVATE --coverage)
-target_include_directories(tests PRIVATE ../include)
-target_link_libraries(tests PRIVATE Threads::Threads)
+target_link_libraries(tests PRIVATE mav Threads::Threads)


### PR DESCRIPTION
The CI workflow wasn't running on pull requests and had several issues that allowed broken commits to land on main. For example, ddc2f59 added `nlohmann/json` as a dependency without CMake integration, and the `gcovr` coverage tool was installed but never executed.

This PR includes three commits:

- **Cherry-pick of #64** (by @streamx3): adds missing `#include <iostream>` for `std::cerr` usage in `Message.h`
- **Add missing nlohmann_json CMake dependency**: `find_package` with `FetchContent` fallback so the build works without a system-wide install. Links the test target to `mav` instead of a hardcoded include path so it inherits transitive dependencies correctly.
- **CI overhaul**:
  - Add `pull_request` trigger so PRs get feedback before merge
  - Scope `push` trigger to `main` only
  - Update `actions/checkout` v3 → v4, add `actions/setup-python` v5
  - Replace direct `./build/tests/tests` with `ctest --test-dir build --output-on-failure`
  - Split coverage into a dedicated job that actually runs `gcovr`
  - Update macOS runner from deprecated `macos-13` to `macos-latest`
  - Install `nlohmann-json3-dev` / `nlohmann-json` on runners

Tested locally on macOS, builds and all tests pass.