### PR TITLE
connection: dispatch callbacks without holding the registry lock

### DIFF
--- a/include/mav/Connection.h
+++ b/include/mav/Connection.h
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include <future>
 #include <utility>
+#include <vector>
 #include "MessageSet.h"
 
 namespace mav {
@@ -109,65 +110,95 @@ namespace mav {
             return _partner;
         }
 
+        // Snapshot the registry, then run callbacks with the lock released, so a callback can take its
+        // own locks or call back into the registry without deadlocking.
         void consumeMessageFromNetwork(const Message& message) noexcept {
             // in case we received a heartbeat, update last heartbeat time, to keep the connection alive.
             _last_received_ms = std::chrono::steady_clock::now();
 
             // if we received a message, we can assume that the connection is working again.
             _underlying_network_fault = false;
+
+            std::vector<std::pair<CallbackHandle, Callback>> snapshot;
             {
                 std::scoped_lock<std::mutex> lock(_message_callback_mtx);
-                auto it = _message_callbacks.begin();
-                while (it != _message_callbacks.end()) {
-                    Callback &callback = it->second;
-                    std::visit([this, &message, &it](auto&& arg) {
-                        using T = std::decay_t<decltype(arg)>;
-                        if constexpr (std::is_same_v<T, FunctionCallback>) {
-                            if (arg.callback) {
-                                arg.callback(message);
-                            }
-                            it++;
-                        } else if constexpr (std::is_same_v<T, PromiseCallback>) {
-                            auto promise = arg.promise.lock();
-                            if (!promise) {
-                                it = _message_callbacks.erase(it);
-                            } else {
-                                if (arg.selector(message)) {
-                                    promise->set_value(message);
-                                    it = _message_callbacks.erase(it);
-                                } else {
-                                    it++;
-                                }
-                            }
-                        }
-                    }, callback);
+                snapshot.reserve(_message_callbacks.size());
+                for (const auto &entry : _message_callbacks) {
+                    snapshot.emplace_back(entry.first, entry.second);
                 }
+            }
+
+            std::vector<CallbackHandle> finished_promises;
+            std::vector<Expectation> to_fulfill;
+            for (auto &entry : snapshot) {
+                std::visit([&](auto&& arg) {
+                    using T = std::decay_t<decltype(arg)>;
+                    if constexpr (std::is_same_v<T, FunctionCallback>) {
+                        if (arg.callback) {
+                            arg.callback(message);
+                        }
+                    } else if constexpr (std::is_same_v<T, PromiseCallback>) {
+                        auto promise = arg.promise.lock();
+                        if (!promise) {
+                            finished_promises.push_back(entry.first);
+                        } else if (arg.selector(message)) {
+                            to_fulfill.push_back(std::move(promise));
+                            finished_promises.push_back(entry.first);
+                        }
+                    }
+                }, entry.second);
+            }
+
+            // erase before fulfilling, so a woken waiter never observes a stale registry
+            if (!finished_promises.empty()) {
+                std::scoped_lock<std::mutex> lock(_message_callback_mtx);
+                for (const auto handle : finished_promises) {
+                    _message_callbacks.erase(handle);
+                }
+            }
+            for (auto &promise : to_fulfill) {
+                promise->set_value(message);
             }
         }
 
         void consumeNetworkExceptionFromNetwork(const std::exception_ptr& exception) noexcept {
             _underlying_network_fault = true;
-            std::scoped_lock<std::mutex> lock(_message_callback_mtx);
-            auto it = _message_callbacks.begin();
-            while (it != _message_callbacks.end()) {
-                Callback &callback = it->second;
-                std::visit([this, &exception, &it](auto&& arg) {
+
+            std::vector<std::pair<CallbackHandle, Callback>> snapshot;
+            {
+                std::scoped_lock<std::mutex> lock(_message_callback_mtx);
+                snapshot.reserve(_message_callbacks.size());
+                for (const auto &entry : _message_callbacks) {
+                    snapshot.emplace_back(entry.first, entry.second);
+                }
+            }
+
+            std::vector<CallbackHandle> finished_promises;
+            std::vector<Expectation> to_fail;
+            for (auto &entry : snapshot) {
+                std::visit([&](auto&& arg) {
                     using T = std::decay_t<decltype(arg)>;
                     if constexpr (std::is_same_v<T, FunctionCallback>) {
                         if (arg.error_callback) {
                             arg.error_callback(exception);
                         }
-                        it++;
                     } else if constexpr (std::is_same_v<T, PromiseCallback>) {
-                        auto promise = arg.promise.lock();
-                        if (!promise) {
-                            it = _message_callbacks.erase(it);
-                        } else {
-                            promise->set_exception(exception);
-                            it = _message_callbacks.erase(it);
+                        if (auto promise = arg.promise.lock()) {
+                            to_fail.push_back(std::move(promise));
                         }
+                        finished_promises.push_back(entry.first);
                     }
-                }, callback);
+                }, entry.second);
+            }
+
+            if (!finished_promises.empty()) {
+                std::scoped_lock<std::mutex> lock(_message_callback_mtx);
+                for (const auto handle : finished_promises) {
+                    _message_callbacks.erase(handle);
+                }
+            }
+            for (auto &promise : to_fail) {
+                promise->set_exception(exception);
             }
         }
 
@@ -231,6 +262,7 @@ namespace mav {
             return addMessageCallback(_message_set.idForMessage(message_name), on_message, source_id, component_id);
         }
 
+        // A callback already in flight may run once more after this returns.
         void removeMessageCallback(CallbackHandle handle) {
             std::scoped_lock<std::mutex> lock(_message_callback_mtx);
             _message_callbacks.erase(handle);

--- a/tests/Network.cpp
+++ b/tests/Network.cpp
@@ -409,4 +409,63 @@ TEST_CASE("Network runtime") {
         }
         connection->removeAllCallbacks();
     }
+
+    SUBCASE("Callback taking a client lock does not deadlock a concurrent registry call") {
+        interface.reset();
+
+        std::mutex client_mutex;
+        std::promise<void> callback_in_dispatch;
+        std::promise<void> callback_finished;
+
+        // callback blocks on client_mutex while it runs
+        connection->addMessageCallback([&](const Message & /*message*/) {
+            callback_in_dispatch.set_value();
+            std::scoped_lock<std::mutex> lock(client_mutex);
+            callback_finished.set_value();
+        });
+
+        // hold client_mutex, then trigger a message so the callback blocks inside dispatch
+        std::unique_lock<std::mutex> client_lock(client_mutex);
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xd9"s, interface_partner);
+        REQUIRE((callback_in_dispatch.get_future().wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+
+        // needs the registry lock; must not deadlock against the in-flight callback
+        auto expectation = connection->expect("HEARTBEAT");
+        (void) expectation;
+
+        client_lock.unlock();
+        CHECK((callback_finished.get_future().wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+
+        connection->removeAllCallbacks();
+    }
+
+    SUBCASE("Callback can register another callback from within dispatch") {
+        interface.reset();
+
+        std::atomic_bool did_register{false};
+        std::atomic_bool inner_fired{false};
+        std::promise<void> outer_ran;
+        std::promise<void> inner_ran;
+
+        connection->addMessageCallback([&](const Message & /*message*/) {
+            if (!did_register.exchange(true)) {
+                connection->addMessageCallback("TEST_MESSAGE", [&](const Message & /*m*/) {
+                    if (!inner_fired.exchange(true)) {
+                        inner_ran.set_value();
+                    }
+                });
+                outer_ran.set_value();
+            }
+        });
+
+        // first message: outer callback registers the inner one
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xd9"s, interface_partner);
+        REQUIRE((outer_ran.get_future().wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+
+        // second message: the newly-registered inner callback must fire
+        interface.addToReceiveQueue("\xfd\x10\x00\x00\x01\x61\x61\xbc\x26\x00\x2a\x00\x00\x00\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x21\x53\xd9"s, interface_partner);
+        CHECK((inner_ran.get_future().wait_for(std::chrono::seconds(2)) != std::future_status::timeout));
+
+        connection->removeAllCallbacks();
+    }
 }


### PR DESCRIPTION
## Problem

`Connection` held `_message_callback_mtx` while invoking user message/error callbacks and while evaluating promise selectors. Registry operations (`expect()`, `addMessageCallback()`, `removeMessageCallback()`, `callbackCount()`, `removeAllCallbacks()`) take that same lock, so dispatching under it causes:

- **Deadlock:** if a callback takes a lock `M` while another thread holds `M` and calls into the registry, the two block on each other (classic AB–BA).
- **No re-entrancy:** a callback that calls `expect()` / `addMessageCallback()` from within dispatch self-deadlocks on the non-recursive mutex.
- **Head-of-line blocking:** a slow callback blocks all registry operations for its duration.

## Fix

Snapshot the callback registry under the lock, then run callbacks and fulfill/fail promises with the lock released — no user code runs while the mutex is held, in both `consumeMessageFromNetwork()` and `consumeNetworkExceptionFromNetwork()`.

Promise entries are erased under the lock *before* their promise is fulfilled, so a thread woken by `set_value` / `set_exception` never observes a stale registry (e.g. `callbackCount()` right after `receive()` returns). Only the receive thread dispatches on a given connection, so a promise is never fulfilled concurrently.

`removeMessageCallback()` now documents the one relaxed guarantee this introduces: a callback already in flight may run once more after it returns.

## Tests

Two new `Network runtime` subcases (both confirmed to hang on the previous code, pass on this one):

- a callback holding a client-side lock does not deadlock a concurrent `expect()`
- a callback can register another callback from within dispatch, and the new callback fires on the next message

Full suite passes both with and without `nlohmann-json` present.
